### PR TITLE
feat: handle items recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ items:
   exclude: true
 - rule: |
     Values.name contains "foo"
-  state_out: foo/terraform.tfstate
+  state_dirname: foo
   resource_name: "{{.Values.name}}"
-  tf_path: foo/resource.tf
+  tf_basename: resource.tf
 - rule: |
     Values.name contains "bar"
-  state_out: bar/terraform.tfstate
+  state_dirname: bar
   resource_name: "{{.Values.name}}"
-  tf_path: bar/resource.tf
+  tf_basename: resource.tf
 ```
 
 ## Restriction

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,10 +9,13 @@ path | type | required | default | description
 path | type | required | default | example | description
 --- | --- | --- | --- | --- | ---
 rule | bool expression | true | | `Type == "null_resource"` | If the result is `true`, the resource is proceeded by the item
-state_out | string | true | | `foo/terraform.tfstate` |
-tf_path | string | true | | `foo/resource.tf` |
+state_dirname | string | true | | `foo` |
+state_basename | string | false | `terraform.tfstate` | |
+tf_basename | string | true | | `main.tf` |
 resource_name | template | false | | `{{.Values.tags.Name}}` | If this isn't empty, the resource is renamed to this value
 exclude | bool | false | false | | If this is true, resources which match the item are ignored 
+stop | bool | false | false | |
+children | []item | false | [] | |
 
 ## type: bool expression
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/sirupsen/logrus v1.8.1
+	github.com/suzuki-shunsuke/go-template-unmarshaler v0.1.0 // indirect
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/suzuki-shunsuke/go-template-unmarshaler v0.1.0 h1:KZDo2ehzMj3zYrTSd6tlguq2kYOE5A88+EIzbwXUV1Q=
+github.com/suzuki-shunsuke/go-template-unmarshaler v0.1.0/go.mod h1:6Qd4LMPwAXbtKvgEoAQ7ZmVVyKcFVBOKTbNVLNtAQzU=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -18,7 +18,8 @@ type Item struct {
 	StateDirname  string        `yaml:"state_dirname"`
 	StateBasename string        `yaml:"state_basename"`
 	ResourceName  *ResourceName `yaml:"resource_name"`
-	TFPath        string        `yaml:"tf_path"`
+	TFDirname     string        `yaml:"tf_dirname"`
+	TFBasename    string        `yaml:"tf_basename"`
 }
 
 type Param struct {
@@ -58,7 +59,8 @@ type DryRunResult struct {
 type MigratedResource struct {
 	SourceResourcePath string `yaml:"source_resource_path"`
 	DestResourcePath   string `yaml:"dest_resource_path"`
-	TFPath             string `yaml:"tf_path"`
+	TFDirname          string `yaml:"tf_dirname"`
+	TFBasename         string `yaml:"tf_basename"`
 	StateDirname       string `yaml:"state_dirname"`
 	StateBasename      string `yaml:"state_basename"`
 }

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -19,7 +19,6 @@ type Item struct {
 	StateDirname  *text.Template `yaml:"state_dirname"`
 	StateBasename *text.Template `yaml:"state_basename"`
 	ResourceName  *ResourceName  `yaml:"resource_name"`
-	TFDirname     string         `yaml:"tf_dirname"`
 	TFBasename    string         `yaml:"tf_basename"`
 }
 
@@ -60,7 +59,6 @@ type DryRunResult struct {
 type MigratedResource struct {
 	SourceResourcePath string         `yaml:"source_resource_path"`
 	DestResourcePath   string         `yaml:"dest_resource_path"`
-	TFDirname          string         `yaml:"tf_dirname"`
 	TFBasename         string         `yaml:"tf_basename"`
 	StateDirname       *text.Template `yaml:"state_dirname"`
 	StateBasename      *text.Template `yaml:"state_basename"`

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -21,6 +21,7 @@ type Item struct {
 	StateBasename *text.Template `yaml:"state_basename"`
 	ResourceName  *ResourceName  `yaml:"resource_name"`
 	TFBasename    *text.Template `yaml:"tf_basename"`
+	Children      []Item
 }
 
 type MatchedItem struct {
@@ -29,6 +30,7 @@ type MatchedItem struct {
 	ResourceName  *ResourceName
 	TFBasename    *text.Template
 	Exclude       bool
+	Stop          bool
 }
 
 func (matchedItem *MatchedItem) Match() bool {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -13,11 +13,12 @@ type Config struct {
 }
 
 type Item struct {
-	Rule         *expr.Bool
-	Exclude      bool
-	StateOut     string        `yaml:"state_out"`
-	ResourceName *ResourceName `yaml:"resource_name"`
-	TFPath       string        `yaml:"tf_path"`
+	Rule          *expr.Bool
+	Exclude       bool
+	StateDirname  string        `yaml:"state_dirname"`
+	StateBasename string        `yaml:"state_basename"`
+	ResourceName  *ResourceName `yaml:"resource_name"`
+	TFPath        string        `yaml:"tf_path"`
 }
 
 type Param struct {
@@ -58,7 +59,8 @@ type MigratedResource struct {
 	SourceResourcePath string `yaml:"source_resource_path"`
 	DestResourcePath   string `yaml:"dest_resource_path"`
 	TFPath             string `yaml:"tf_path"`
-	StateOut           string `yaml:"state_out"`
+	StateDirname       string `yaml:"state_dirname"`
+	StateBasename      string `yaml:"state_basename"`
 }
 
 func (ctrl *Controller) readConfig(param Param, cfg *Config) error {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -16,7 +16,7 @@ type Config struct {
 type Item struct {
 	Rule          *expr.Bool
 	Exclude       bool
-	StateDirname  string         `yaml:"state_dirname"`
+	StateDirname  *text.Template `yaml:"state_dirname"`
 	StateBasename *text.Template `yaml:"state_basename"`
 	ResourceName  *ResourceName  `yaml:"resource_name"`
 	TFDirname     string         `yaml:"tf_dirname"`
@@ -62,7 +62,7 @@ type MigratedResource struct {
 	DestResourcePath   string         `yaml:"dest_resource_path"`
 	TFDirname          string         `yaml:"tf_dirname"`
 	TFBasename         string         `yaml:"tf_basename"`
-	StateDirname       string         `yaml:"state_dirname"`
+	StateDirname       *text.Template `yaml:"state_dirname"`
 	StateBasename      *text.Template `yaml:"state_basename"`
 }
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/suzuki-shunsuke/go-template-unmarshaler/text"
 	"github.com/suzuki-shunsuke/tfmigrator/pkg/expr"
 	"gopkg.in/yaml.v2"
 )
@@ -15,11 +16,11 @@ type Config struct {
 type Item struct {
 	Rule          *expr.Bool
 	Exclude       bool
-	StateDirname  string        `yaml:"state_dirname"`
-	StateBasename string        `yaml:"state_basename"`
-	ResourceName  *ResourceName `yaml:"resource_name"`
-	TFDirname     string        `yaml:"tf_dirname"`
-	TFBasename    string        `yaml:"tf_basename"`
+	StateDirname  string         `yaml:"state_dirname"`
+	StateBasename *text.Template `yaml:"state_basename"`
+	ResourceName  *ResourceName  `yaml:"resource_name"`
+	TFDirname     string         `yaml:"tf_dirname"`
+	TFBasename    string         `yaml:"tf_basename"`
 }
 
 type Param struct {
@@ -57,12 +58,12 @@ type DryRunResult struct {
 }
 
 type MigratedResource struct {
-	SourceResourcePath string `yaml:"source_resource_path"`
-	DestResourcePath   string `yaml:"dest_resource_path"`
-	TFDirname          string `yaml:"tf_dirname"`
-	TFBasename         string `yaml:"tf_basename"`
-	StateDirname       string `yaml:"state_dirname"`
-	StateBasename      string `yaml:"state_basename"`
+	SourceResourcePath string         `yaml:"source_resource_path"`
+	DestResourcePath   string         `yaml:"dest_resource_path"`
+	TFDirname          string         `yaml:"tf_dirname"`
+	TFBasename         string         `yaml:"tf_basename"`
+	StateDirname       string         `yaml:"state_dirname"`
+	StateBasename      *text.Template `yaml:"state_basename"`
 }
 
 func (ctrl *Controller) readConfig(param Param, cfg *Config) error {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -19,7 +19,7 @@ type Item struct {
 	StateDirname  *text.Template `yaml:"state_dirname"`
 	StateBasename *text.Template `yaml:"state_basename"`
 	ResourceName  *ResourceName  `yaml:"resource_name"`
-	TFBasename    string         `yaml:"tf_basename"`
+	TFBasename    *text.Template `yaml:"tf_basename"`
 }
 
 type Param struct {
@@ -59,7 +59,7 @@ type DryRunResult struct {
 type MigratedResource struct {
 	SourceResourcePath string         `yaml:"source_resource_path"`
 	DestResourcePath   string         `yaml:"dest_resource_path"`
-	TFBasename         string         `yaml:"tf_basename"`
+	TFBasename         *text.Template `yaml:"tf_basename"`
 	StateDirname       *text.Template `yaml:"state_dirname"`
 	StateBasename      *text.Template `yaml:"state_basename"`
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"io"
 	"os"
+	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/go-template-unmarshaler/text"
 )
 
 type Controller struct { //nolint:maligned
@@ -24,6 +27,10 @@ func New(ctx context.Context, param Param) (Controller, Param, error) {
 		}
 		logrus.SetLevel(lvl)
 	}
+
+	text.SetTemplateFunc(func(s string) (*template.Template, error) {
+		return template.New("_").Funcs(sprig.TxtFuncMap()).Parse(s) //nolint:wrapcheck
+	})
 
 	return Controller{
 		Stdin:  os.Stdin,

--- a/pkg/controller/resource_path.go
+++ b/pkg/controller/resource_path.go
@@ -14,6 +14,10 @@ type ResourceName struct {
 	raw  string
 }
 
+func (resourceName *ResourceName) Empty() bool {
+	return resourceName == nil || resourceName.tmpl == nil
+}
+
 func (resourceName *ResourceName) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var a string
 	if err := unmarshal(&a); err != nil {

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -177,7 +177,12 @@ func (ctrl *Controller) handleItem(ctx context.Context, rsc Resource, item Item,
 		return true, fmt.Errorf("render a state_dirname: %w", err)
 	}
 
-	tfPath := filepath.Join(stateDirname, item.TFBasename)
+	tfBasename, err := item.TFBasename.Execute(rsc)
+	if err != nil {
+		return true, fmt.Errorf("render a tf_basename: %w", err)
+	}
+
+	tfPath := filepath.Join(stateDirname, tfBasename)
 	tfFile, err := os.OpenFile(tfPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return true, fmt.Errorf("open a file which will write Terraform configuration %s: %w", tfPath, err)

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v2"
 )
@@ -154,7 +155,8 @@ func (ctrl *Controller) handleItem(ctx context.Context, rsc Resource, item Item,
 			SourceResourcePath: resourcePath.Path(),
 			DestResourcePath:   newResourcePath.Path(),
 			TFPath:             item.TFPath,
-			StateOut:           item.StateOut,
+			StateDirname:       item.StateDirname,
+			StateBasename:      item.StateBasename,
 		})
 		return true, nil
 	}
@@ -176,7 +178,7 @@ func (ctrl *Controller) handleItem(ctx context.Context, rsc Resource, item Item,
 		return true, err
 	}
 
-	if err := ctrl.stateMv(ctx, item.StateOut, resourcePath.Path(), newResourcePath.Path(), param.SkipState); err != nil {
+	if err := ctrl.stateMv(ctx, filepath.Join(item.StateDirname, item.StateBasename), resourcePath.Path(), newResourcePath.Path(), param.SkipState); err != nil {
 		return true, err
 	}
 	// write hcl

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -185,7 +185,12 @@ func (ctrl *Controller) handleItem(ctx context.Context, rsc Resource, item Item,
 		return true, fmt.Errorf("render a state_basename: %w", err)
 	}
 
-	if err := ctrl.stateMv(ctx, filepath.Join(item.StateDirname, stateBasename), resourcePath.Path(), newResourcePath.Path(), param.SkipState); err != nil {
+	stateDirname, err := item.StateDirname.Execute(rsc)
+	if err != nil {
+		return true, fmt.Errorf("render a state_dirname: %w", err)
+	}
+
+	if err := ctrl.stateMv(ctx, filepath.Join(stateDirname, stateBasename), resourcePath.Path(), newResourcePath.Path(), param.SkipState); err != nil {
 		return true, err
 	}
 	// write hcl

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -180,7 +180,12 @@ func (ctrl *Controller) handleItem(ctx context.Context, rsc Resource, item Item,
 		return true, err
 	}
 
-	if err := ctrl.stateMv(ctx, filepath.Join(item.StateDirname, item.StateBasename), resourcePath.Path(), newResourcePath.Path(), param.SkipState); err != nil {
+	stateBasename, err := item.StateBasename.Execute(rsc)
+	if err != nil {
+		return true, fmt.Errorf("render a state_basename: %w", err)
+	}
+
+	if err := ctrl.stateMv(ctx, filepath.Join(item.StateDirname, stateBasename), resourcePath.Path(), newResourcePath.Path(), param.SkipState); err != nil {
 		return true, err
 	}
 	// write hcl

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -154,7 +154,8 @@ func (ctrl *Controller) handleItem(ctx context.Context, rsc Resource, item Item,
 		dryRunResult.MigratedResources = append(dryRunResult.MigratedResources, MigratedResource{
 			SourceResourcePath: resourcePath.Path(),
 			DestResourcePath:   newResourcePath.Path(),
-			TFPath:             item.TFPath,
+			TFDirname:          item.TFDirname,
+			TFBasename:         item.TFBasename,
 			StateDirname:       item.StateDirname,
 			StateBasename:      item.StateBasename,
 		})
@@ -167,9 +168,10 @@ func (ctrl *Controller) handleItem(ctx context.Context, rsc Resource, item Item,
 	}
 	defer hclFile.Close()
 
-	tfFile, err := os.OpenFile(item.TFPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	tfPath := filepath.Join(item.TFDirname, item.TFBasename)
+	tfFile, err := os.OpenFile(tfPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return true, fmt.Errorf("open a file which will write Terraform configuration %s: %w", item.TFPath, err)
+		return true, fmt.Errorf("open a file which will write Terraform configuration %s: %w", tfPath, err)
 	}
 	defer tfFile.Close()
 
@@ -183,7 +185,7 @@ func (ctrl *Controller) handleItem(ctx context.Context, rsc Resource, item Item,
 	}
 	// write hcl
 	if _, err := io.Copy(tfFile, &buf); err != nil {
-		return true, fmt.Errorf("write Terraform configuration to a file %s: %w", item.TFPath, err)
+		return true, fmt.Errorf("write Terraform configuration to a file %s: %w", tfPath, err)
 	}
 	return true, nil
 }


### PR DESCRIPTION
## BREAKING CHANGE

* some configuration fields are removed
  * item.state_out: use `item.state_dirname` and `item.state_basename`
  * item.tf_path: use `item.state_dirname` and `item.tf_basename`
* even if a resource matches an item, the process of the resource continues
  * support to apply multiple items to the same resource

## Feature

* support templates in `item.state_dirname`, `item.state_basename`, and `item.tf_basename`
* support nested items