### PR TITLE
Revert "chore: rename repository from tfmigrator to tfmigrator-cli"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,11 @@
-# tfmigrator-cli
+# tfmigrator
 
-[![Build Status](https://github.com/suzuki-shunsuke/tfmigrator-cli/workflows/test/badge.svg)](https://github.com/suzuki-shunsuke/tfmigrator-cli/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/suzuki-shunsuke/tfmigrator-cli)](https://goreportcard.com/report/github.com/suzuki-shunsuke/tfmigrator-cli)
-[![GitHub last commit](https://img.shields.io/github/last-commit/suzuki-shunsuke/tfmigrator-cli.svg)](https://github.com/suzuki-shunsuke/tfmigrator-cli)
-[![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/suzuki-shunsuke/tfmigrator-cli/main/LICENSE)
+[![Build Status](https://github.com/suzuki-shunsuke/tfmigrator/workflows/test/badge.svg)](https://github.com/suzuki-shunsuke/tfmigrator/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/suzuki-shunsuke/tfmigrator)](https://goreportcard.com/report/github.com/suzuki-shunsuke/tfmigrator)
+[![GitHub last commit](https://img.shields.io/github/last-commit/suzuki-shunsuke/tfmigrator.svg)](https://github.com/suzuki-shunsuke/tfmigrator)
+[![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/suzuki-shunsuke/tfmigrator/main/LICENSE)
 
 CLI tool to migrate Terraform configuration and State
-
-## Note: this CLI was renamed from tfmigrator to tfmigrator-cli
-
-This repository was renamed from tfmigrator to tfmigrator-cli, because we started to develop tfmigrator as Go package (framework).
-
-https://github.com/suzuki-shunsuke/tfmigrator-cli/issues/25
 
 ## Blog written in Japanese
 
@@ -29,7 +23,7 @@ https://github.com/suzuki-shunsuke/tfmigrator-cli/issues/25
 
 ## Install
 
-Download a binary from the [replease page](https://github.com/suzuki-shunsuke/tfmigrator-cli/releases).
+Download a binary from the [replease page](https://github.com/suzuki-shunsuke/tfmigrator/releases).
 
 ## How to use
 

--- a/cmd/tfmigrator/main.go
+++ b/cmd/tfmigrator/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/suzuki-shunsuke/tfmigrator-cli/pkg/cli"
-	"github.com/suzuki-shunsuke/tfmigrator-cli/pkg/signal"
+	"github.com/suzuki-shunsuke/tfmigrator/pkg/cli"
+	"github.com/suzuki-shunsuke/tfmigrator/pkg/signal"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/suzuki-shunsuke/tfmigrator-cli
+module github.com/suzuki-shunsuke/tfmigrator
 
 go 1.15
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/suzuki-shunsuke/tfmigrator-cli/pkg/controller"
+	"github.com/suzuki-shunsuke/tfmigrator/pkg/controller"
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/suzuki-shunsuke/tfmigrator-cli/pkg/constant"
+	"github.com/suzuki-shunsuke/tfmigrator/pkg/constant"
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/suzuki-shunsuke/tfmigrator-cli/pkg/expr"
+	"github.com/suzuki-shunsuke/tfmigrator/pkg/expr"
 	"gopkg.in/yaml.v2"
 )
 

--- a/pkg/expr/bool_test.go
+++ b/pkg/expr/bool_test.go
@@ -3,7 +3,7 @@ package expr_test
 import (
 	"testing"
 
-	"github.com/suzuki-shunsuke/tfmigrator-cli/pkg/expr"
+	"github.com/suzuki-shunsuke/tfmigrator/pkg/expr"
 	"gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
Reverts suzuki-shunsuke/tfmigrator#26

We tried to publish a new Go package as suzuki-shunsuke/tfmigrator, but it was difficult.

https://github.com/tfmigrator/tfmigrator/pull/7

So I gave up renaming the repository.